### PR TITLE
customize edges of bars in bar charts

### DIFF
--- a/demo/app.component.html
+++ b/demo/app.component.html
@@ -22,6 +22,7 @@
         [showGridLines]="showGridLines"
         [barPadding]="barPadding"
         [roundDomains]="roundDomains"
+        [roundEdges]="roundEdges"
         (select)="select($event)"
         (legendLabelClick)="onLegendLabelClick($event)">
       </ngx-charts-bar-vertical>
@@ -45,6 +46,7 @@
         [showGridLines]="showGridLines"
         [barPadding]="barPadding"
         [roundDomains]="roundDomains"
+        [roundEdges]="roundEdges"
         (legendLabelClick)="onLegendLabelClick($event)"
         (select)="select($event)">
       </ngx-charts-bar-horizontal>
@@ -70,6 +72,7 @@
         [barPadding]="barPadding"
         [groupPadding]="groupPadding"
         [roundDomains]="roundDomains"
+        [roundEdges]="roundEdges"
         (select)="select($event)">
       </ngx-charts-bar-vertical-2d>
       <ngx-charts-bar-horizontal-2d
@@ -94,6 +97,7 @@
         [barPadding]="barPadding"
         [groupPadding]="groupPadding"
         [roundDomains]="roundDomains"
+        [roundEdges]="roundEdges"
         (select)="select($event)">
       </ngx-charts-bar-horizontal-2d>
       <ngx-charts-bar-vertical-stacked
@@ -767,6 +771,12 @@
         <label>
           <input type="checkbox" [checked]="showLegend" (change)="showLegend = $event.target.checked">
           Show Legend
+        </label> <br />
+      </div>
+      <div *ngIf="chart.options.includes('roundEdges')">
+        <label>
+          <input type="checkbox" [checked]="roundEdges" (change)="roundEdges = $event.target.checked">
+          Round Bar Edges
         </label> <br />
       </div>
       <div *ngIf="chart.options.includes('legendTitle')">

--- a/demo/app.component.ts
+++ b/demo/app.component.ts
@@ -46,6 +46,7 @@ export class AppComponent implements OnInit {
   dateDataWithRange: any[];
   calendarData: any[];
   statusData: any[];
+  sparklineData: any[];
   graph: { links: any[], nodes: any[] };
   bubble: any;
   linearScale: boolean = false;
@@ -75,6 +76,7 @@ export class AppComponent implements OnInit {
   maxRadius = 10;
   minRadius = 3;
   showSeriesOnHover = true;
+  roundEdges: boolean = true;
 
   curves = {
     Basis: shape.curveBasis,

--- a/demo/chartTypes.ts
+++ b/demo/chartTypes.ts
@@ -9,7 +9,7 @@ const chartGroups = [
         options: [
           'colorScheme', 'schemeType', 'showXAxis', 'showYAxis', 'gradient', 'barPadding',
           'showLegend', 'legendTitle', 'showXAxisLabel', 'xAxisLabel', 'showYAxisLabel', 'yAxisLabel',
-          'showGridLines', 'roundDomains', 'tooltipDisabled'
+          'showGridLines', 'roundDomains', 'tooltipDisabled', 'roundEdges'
         ]
       },
       {
@@ -19,7 +19,7 @@ const chartGroups = [
         options: [
           'colorScheme', 'schemeType', 'showXAxis', 'showYAxis', 'gradient', 'barPadding',
           'showLegend', 'legendTitle', 'showXAxisLabel', 'xAxisLabel', 'showYAxisLabel', 'yAxisLabel',
-          'showGridLines', 'roundDomains', 'tooltipDisabled'
+          'showGridLines', 'roundDomains', 'tooltipDisabled', 'roundEdges'
         ],
         defaults: {
           yAxisLabel: 'Country',
@@ -33,7 +33,7 @@ const chartGroups = [
         options: [
           'colorScheme', 'schemeType', 'showXAxis', 'showYAxis', 'gradient', 'barPadding', 'groupPadding',
           'showLegend', 'legendTitle', 'showXAxisLabel', 'xAxisLabel', 'showYAxisLabel', 'yAxisLabel',
-          'showGridLines', 'roundDomains', 'tooltipDisabled'
+          'showGridLines', 'roundDomains', 'tooltipDisabled', 'roundEdges'
         ]
       },
       {
@@ -43,7 +43,7 @@ const chartGroups = [
         options: [
           'colorScheme', 'schemeType', 'showXAxis', 'showYAxis', 'gradient', 'barPadding', 'groupPadding',
           'showLegend', 'legendTitle', 'showXAxisLabel', 'xAxisLabel', 'showYAxisLabel', 'yAxisLabel',
-          'showGridLines', 'roundDomains', 'tooltipDisabled'
+          'showGridLines', 'roundDomains', 'tooltipDisabled', 'roundEdges'
         ],
         defaults: {
           yAxisLabel: 'Country',

--- a/src/bar-chart/bar-horizontal-2d.component.ts
+++ b/src/bar-chart/bar-horizontal-2d.component.ts
@@ -72,6 +72,7 @@ import { BaseChartComponent } from '../common/base-chart.component';
             [gradient]="gradient"
             [tooltipDisabled]="tooltipDisabled"
             [seriesName]="group.name"
+            [roundEdges]="roundEdges"
             (select)="onClick($event, group)"
             (activate)="onActivate($event, group)"
             (deactivate)="onDeactivate($event, group)"
@@ -115,6 +116,7 @@ export class BarHorizontal2DComponent extends BaseChartComponent {
   @Input() groupPadding = 16;
   @Input() barPadding = 8;
   @Input() roundDomains: boolean = false;
+  @Input() roundEdges: boolean = true;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();

--- a/src/bar-chart/bar-horizontal.component.ts
+++ b/src/bar-chart/bar-horizontal.component.ts
@@ -52,6 +52,7 @@ import { BaseChartComponent } from '../common/base-chart.component';
           [gradient]="gradient"
           [tooltipDisabled]="tooltipDisabled"
           [activeEntries]="activeEntries"
+          [roundEdges]="roundEdges"
           (select)="onClick($event)"
           (activate)="onActivate($event)"
           (deactivate)="onDeactivate($event)"
@@ -82,6 +83,7 @@ export class BarHorizontalComponent extends BaseChartComponent {
   @Input() yAxisTickFormatting: any;
   @Input() barPadding = 8;
   @Input() roundDomains: boolean = false;
+  @Input() roundEdges: boolean = true;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();

--- a/src/bar-chart/bar-vertical-2d.component.ts
+++ b/src/bar-chart/bar-vertical-2d.component.ts
@@ -70,6 +70,7 @@ import { BaseChartComponent } from '../common/base-chart.component';
           [gradient]="gradient"
           [tooltipDisabled]="tooltipDisabled"
           [seriesName]="group.name"
+          [roundEdges]="roundEdges"
           (select)="onClick($event, group)"
           (activate)="onActivate($event, group)"
           (deactivate)="onDeactivate($event, group)"
@@ -113,6 +114,7 @@ export class BarVertical2DComponent extends BaseChartComponent {
   @Input() groupPadding = 16;
   @Input() barPadding = 8;
   @Input() roundDomains: boolean = false;
+  @Input() roundEdges: boolean = true;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();

--- a/src/bar-chart/bar-vertical.component.ts
+++ b/src/bar-chart/bar-vertical.component.ts
@@ -52,6 +52,7 @@ import { BaseChartComponent } from '../common/base-chart.component';
           [gradient]="gradient"
           [tooltipDisabled]="tooltipDisabled"
           [activeEntries]="activeEntries"
+          [roundEdges]="roundEdges"
           (activate)="onActivate($event)"
           (deactivate)="onDeactivate($event)"
           (select)="onClick($event)">
@@ -82,6 +83,7 @@ export class BarVerticalComponent extends BaseChartComponent {
   @Input() yAxisTickFormatting: any;
   @Input() barPadding = 8;
   @Input() roundDomains: boolean = false;
+  @Input() roundEdges: boolean = true;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();

--- a/src/bar-chart/series-horizontal.component.ts
+++ b/src/bar-chart/series-horizontal.component.ts
@@ -71,6 +71,7 @@ export class SeriesHorizontal implements OnChanges {
   @Input() gradient: boolean;
   @Input() activeEntries: any[];
   @Input() seriesName: string;
+  @Input() roundEdges: boolean;
 
   @Output() select = new EventEmitter();
   @Output() activate = new EventEmitter();
@@ -91,7 +92,7 @@ export class SeriesHorizontal implements OnChanges {
       let value = d.value;
       const label = d.name;
       const formattedLabel = formatLabel(label);
-      const roundEdges = this.type === 'standard';
+      const roundEdges = this.roundEdges;
 
       const bar: any = {
         value,

--- a/src/bar-chart/series-vertical.component.ts
+++ b/src/bar-chart/series-vertical.component.ts
@@ -66,6 +66,7 @@ export class SeriesVerticalComponent implements OnChanges {
   @Input() gradient: boolean;
   @Input() activeEntries: any[];
   @Input() seriesName: string;
+  @Input() roundEdges: boolean;
 
   @Output() select = new EventEmitter();
   @Output() activate = new EventEmitter();
@@ -95,7 +96,7 @@ export class SeriesVerticalComponent implements OnChanges {
       let value = d.value;
       const label = d.name;
       const formattedLabel = formatLabel(label);
-      const roundEdges = this.type === 'standard';
+      const roundEdges = this.roundEdges;
 
       const bar: any = {
         value,


### PR DESCRIPTION
expose roundEdges input property to allow custom setting of bar rounded edges in bar charts.
roundEdges = true => default setting, rounds bar edges.
roundEdges = false => square bar edges